### PR TITLE
Fix: Always install latest marimo, dynamic versioning, background process

### DIFF
--- a/marimo-demo.py
+++ b/marimo-demo.py
@@ -5,7 +5,7 @@ Try this to see reactive programming in action!
 
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.0.0"  # Dynamically set by studio-lab-setup.sh
 app = marimo.App(width="medium")
 
 

--- a/sagemaker_ml_demo.py
+++ b/sagemaker_ml_demo.py
@@ -14,7 +14,7 @@ Or as an app: marimo run sagemaker_ml_demo.py
 
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.0.0"  # Dynamically set by studio-lab-setup.sh
 app = marimo.App(width="full")
 
 

--- a/start-marimo-improved.sh
+++ b/start-marimo-improved.sh
@@ -76,6 +76,13 @@ echo ""
 echo "================================================"
 echo ""
 
-# Start marimo
+# Start marimo in the background so the terminal remains usable
 # Use default port 2718 (Studio Lab's proxy default)
-marimo edit --host 0.0.0.0 --port 2718 --no-token --headless
+marimo edit --host 0.0.0.0 --port 2718 --no-token --headless &
+MARIMO_PID=$!
+echo "marimo started (PID: $MARIMO_PID)"
+echo "To stop marimo: kill $MARIMO_PID"
+echo ""
+
+# Wait for marimo to exit (optional - press Ctrl+C to return to terminal)
+wait $MARIMO_PID 2>/dev/null

--- a/studio-lab-setup.sh
+++ b/studio-lab-setup.sh
@@ -27,7 +27,7 @@ dependencies:
   - python=3.9
   - pip
   - pip:
-    - marimo>=0.17.6
+    - marimo
     - jupyter-server-proxy==$PROXY_VERSION
     - pandas>=2.0.0
     - numpy>=1.24.0
@@ -42,7 +42,7 @@ echo "   Note: Using jupyter-server-proxy $PROXY_VERSION (4.x breaks SageMaker)"
 echo ""
 echo "📝 Creating requirements.txt..."
 cat > "$REQUIREMENTS_FILE" << EOF
-marimo>=0.17.6
+marimo
 jupyter-server-proxy==$PROXY_VERSION
 pandas>=2.0.0
 numpy>=1.24.0
@@ -173,11 +173,18 @@ echo ""
 echo "================================================"
 echo ""
 
-# Start marimo
+# Start marimo in the background so the terminal remains usable
 # Use default port 2718 with Studio Lab-compatible flags
 # --no-token: Jupyter already handles authentication
 # --headless: Proxy-friendly mode for Studio Lab
-marimo edit --host 0.0.0.0 --port 2718 --no-token --headless
+marimo edit --host 0.0.0.0 --port 2718 --no-token --headless &
+MARIMO_PID=$!
+echo "marimo started (PID: $MARIMO_PID)"
+echo "To stop marimo: kill $MARIMO_PID"
+echo ""
+
+# Wait for marimo to exit (optional - press Ctrl+C to return to terminal)
+wait $MARIMO_PID 2>/dev/null
 EOFSTART
 
 chmod +x ~/start-marimo.sh
@@ -254,7 +261,7 @@ Try this to see reactive programming in action!
 
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "MARIMO_VERSION_PLACEHOLDER"
 app = marimo.App(width="medium")
 
 
@@ -388,7 +395,21 @@ def __(mo):
 if __name__ == "__main__":
     app.run()
 EOFDEMO
-echo "✅ Demo notebook created: ~/marimo-demo.py"
+
+# Set __generated_with to the actually installed marimo version
+MARIMO_VERSION=$(marimo --version 2>&1 || echo "0.0.0")
+sed -i "s/MARIMO_VERSION_PLACEHOLDER/$MARIMO_VERSION/" ~/marimo-demo.py
+echo "✅ Demo notebook created: ~/marimo-demo.py (marimo $MARIMO_VERSION)"
+
+# Also update __generated_with in any repo notebooks that were cloned
+if [ -d ~/aws-marimo ]; then
+    for nb in ~/aws-marimo/marimo-demo.py ~/aws-marimo/sagemaker_ml_demo.py; do
+        if [ -f "$nb" ]; then
+            sed -i "s/__generated_with = \"[^\"]*\"/__generated_with = \"$MARIMO_VERSION\"/" "$nb"
+        fi
+    done
+    echo "✅ Updated repo notebooks to marimo $MARIMO_VERSION"
+fi
 
 # Step 8: Summary
 echo ""


### PR DESCRIPTION
## Summary

- **Remove marimo version pin** (`>=0.17.6` → unpinned) so every fresh deployment installs the latest marimo from PyPI
- **Dynamically set `__generated_with`** in notebook files to match the actually installed marimo version at setup time — fixes the blank notebook rendering caused by version mismatch (e.g., notebook tagged as 0.21.1 but marimo 0.17.6 installed)
- **Background the marimo process** in start scripts (`&` + `wait`) so the terminal remains usable for diagnostics without needing to open a second terminal
- **Update cloned repo notebooks** during setup so `marimo-demo.py` and `sagemaker_ml_demo.py` also get the correct version tag

## Issues Fixed

Closes #1 — Demo notebook renders blank due to `__generated_with` version mismatch
Closes #2 — Start script blocks terminal (marimo runs in foreground)
Closes #3 — `sagemaker_ml_demo.py` has same version mismatch issue as demo notebook

## Files Changed

| File | Changes |
|------|---------|
| `studio-lab-setup.sh` | Remove version pin, dynamic `__generated_with` via sed, background marimo in generated start script, update repo notebooks post-install |
| `start-marimo-improved.sh` | Background marimo with `&` + `wait`, print PID for easy stop |
| `marimo-demo.py` | Set `__generated_with = "0.0.0"` as placeholder (dynamically replaced at setup) |
| `sagemaker_ml_demo.py` | Same placeholder approach as marimo-demo.py |

## Test plan

- [ ] Run `studio-lab-setup.sh` on a fresh SageMaker Studio Lab environment
- [ ] Verify marimo installs as latest version (not pinned to 0.17.6)
- [ ] Open `marimo-demo.py` — should render correctly (not blank)
- [ ] Open `sagemaker_ml_demo.py` — should render correctly (not blank)
- [ ] Verify terminal remains usable after running `start-marimo.sh`
- [ ] Test bootstrap one-liner: `curl -fsSL https://raw.githubusercontent.com/scttfrdmn/aws-marimo/main/bootstrap.sh | bash`